### PR TITLE
fix(BookingShow): arreglado para que cuando entras a un booking (show)

### DIFF
--- a/src/main/java/acme/features/customer/booking/CustomerBookingShowService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingShowService.java
@@ -64,7 +64,7 @@ public class CustomerBookingShowService extends AbstractGuiService<Customer, Boo
 			boolean flightStillValid = avaiableFlights.contains(booking.getFlight());
 
 			if (!flightStillValid) {
-				SelectChoices choices = SelectChoices.from(avaiableFlights, "label", booking.getFlight());
+				SelectChoices choices = SelectChoices.from(avaiableFlights, "label", avaiableFlights.stream().findFirst().get());
 				dataset.put("flight", choices.getSelected() != null ? choices.getSelected().getKey() : "0");
 				dataset.put("flights", choices);
 			} else {


### PR DESCRIPTION
que ya habia sido creado con el sample data y no esta publicado pero cuando se creó se puso un vuelo que actualmente es pasado, no de error. Ahora cuando te metes es un booking que no esta publicado y el vuelo que se le asoció ya ha pasado, no da error sino que se pone en el selectChoices.getSelected() el primer vuelo de los que se pueden elegir(futuro)